### PR TITLE
feat(meta): replace msg.sender

### DIFF
--- a/contracts/facets/FoundryFacet.sol
+++ b/contracts/facets/FoundryFacet.sol
@@ -13,6 +13,7 @@ import {LibMeToken} from "../libs/LibMeToken.sol";
 import {LibHub} from "../libs/LibHub.sol";
 import {LibWeightedAverage} from "../libs/LibWeightedAverage.sol";
 import "../libs/Details.sol";
+import "../libs/LibMeta.sol";
 
 contract FoundryFacet is IFoundry, Modifiers {
     // MINT FLOW CHART
@@ -41,6 +42,7 @@ contract FoundryFacet is IFoundry, Modifiers {
         uint256 _assetsDeposited,
         address _recipient
     ) external override {
+        address sender = LibMeta.msgSender();
         MeTokenInfo memory meToken_ = s.meTokens[_meToken];
         HubInfo memory hub_ = s.hubs[meToken_.hubId];
 
@@ -80,7 +82,7 @@ contract FoundryFacet is IFoundry, Modifiers {
             asset = s.hubs[meToken_.targetHubId].asset;
         }
 
-        vault.handleDeposit(msg.sender, asset, _assetsDeposited, fee);
+        vault.handleDeposit(sender, asset, _assetsDeposited, fee);
 
         LibMeToken.updateBalancePooled(
             true,
@@ -92,7 +94,7 @@ contract FoundryFacet is IFoundry, Modifiers {
         emit Mint(
             _meToken,
             asset,
-            msg.sender,
+            sender,
             _recipient,
             _assetsDeposited,
             meTokensMinted
@@ -137,6 +139,7 @@ contract FoundryFacet is IFoundry, Modifiers {
         uint256 _meTokensBurned,
         address _recipient
     ) external override {
+        address sender = LibMeta.msgSender();
         MeTokenInfo memory meToken_ = s.meTokens[_meToken];
         HubInfo memory hub_ = s.hubs[meToken_.hubId];
 
@@ -154,7 +157,7 @@ contract FoundryFacet is IFoundry, Modifiers {
             _meTokensBurned
         );
         uint256 assetsReturned = _calculateActualAssetsReturned(
-            msg.sender,
+            sender,
             _meToken,
             _meTokensBurned,
             rawAssetsReturned
@@ -164,19 +167,19 @@ contract FoundryFacet is IFoundry, Modifiers {
         // If msg.sender == owner, give owner the sell rate. - all of tokens returned plus a %
         //      of balancePooled based on how much % of supply will be burned
         // If msg.sender != owner, give msg.sender the burn rate
-        if (msg.sender == meToken_.owner) {
+        if (sender == meToken_.owner) {
             feeRate = s.burnOwnerFee;
         } else {
             feeRate = s.burnBuyerFee;
         }
 
         // Burn metoken from user
-        IMeToken(_meToken).burn(msg.sender, _meTokensBurned);
+        IMeToken(_meToken).burn(sender, _meTokensBurned);
 
         // Subtract tokens returned from balance pooled
         LibMeToken.updateBalancePooled(false, _meToken, rawAssetsReturned);
 
-        if (msg.sender == meToken_.owner) {
+        if (sender == meToken_.owner) {
             // Is owner, subtract from balance locked
             LibMeToken.updateBalanceLocked(
                 false,
@@ -210,7 +213,7 @@ contract FoundryFacet is IFoundry, Modifiers {
         emit Burn(
             _meToken,
             asset,
-            msg.sender,
+            sender,
             _recipient,
             _meTokensBurned,
             assetsReturned
@@ -221,6 +224,7 @@ contract FoundryFacet is IFoundry, Modifiers {
         external
         override
     {
+        address sender = LibMeta.msgSender();
         MeTokenInfo memory meToken_ = s.meTokens[_meToken];
         HubInfo memory hub_ = s.hubs[meToken_.hubId];
         require(meToken_.migration == address(0), "meToken resubscribing");
@@ -228,11 +232,11 @@ contract FoundryFacet is IFoundry, Modifiers {
         IVault vault = IVault(hub_.vault);
         address asset = hub_.asset;
 
-        vault.handleDeposit(msg.sender, asset, _assetsDeposited, 0);
+        vault.handleDeposit(sender, asset, _assetsDeposited, 0);
 
         LibMeToken.updateBalanceLocked(true, _meToken, _assetsDeposited);
 
-        emit Donate(_meToken, asset, msg.sender, _assetsDeposited);
+        emit Donate(_meToken, asset, sender, _assetsDeposited);
     }
 
     // NOTE: for now this does not include fees

--- a/contracts/facets/HubFacet.sol
+++ b/contracts/facets/HubFacet.sol
@@ -86,8 +86,10 @@ contract HubFacet is Modifiers {
 
     function deactivate(uint256 _id) external {
         HubInfo storage hub_ = s.hubs[_id];
+
+        address sender = LibMeta.msgSender();
         require(
-            msg.sender == hub_.owner || msg.sender == s.deactivateController,
+            sender == hub_.owner || sender == s.deactivateController,
             "!owner && !deactivateController"
         );
         require(hub_.active, "!active");
@@ -102,7 +104,9 @@ contract HubFacet is Modifiers {
         bytes memory _encodedCurveDetails
     ) external {
         HubInfo storage hub_ = s.hubs[_id];
-        require(msg.sender == hub_.owner, "!owner");
+
+        address sender = LibMeta.msgSender();
+        require(sender == hub_.owner, "!owner");
         if (hub_.updating && block.timestamp > hub_.endTime) {
             LibHub.finishUpdate(_id);
         }
@@ -171,7 +175,8 @@ contract HubFacet is Modifiers {
 
     function cancelUpdate(uint256 _id) external {
         HubInfo storage hub_ = s.hubs[_id];
-        require(msg.sender == hub_.owner, "!owner");
+        address sender = LibMeta.msgSender();
+        require(sender == hub_.owner, "!owner");
         require(hub_.updating, "!updating");
         require(block.timestamp < hub_.startTime, "Update has started");
 
@@ -188,7 +193,8 @@ contract HubFacet is Modifiers {
 
     function transferHubOwnership(uint256 _id, address _newOwner) external {
         HubInfo storage hub_ = s.hubs[_id];
-        require(msg.sender == hub_.owner, "!owner");
+        address sender = LibMeta.msgSender();
+        require(sender == hub_.owner, "!owner");
         require(_newOwner != hub_.owner, "Same owner");
         hub_.owner = _newOwner;
 

--- a/contracts/facets/MeTokenRegistryFacet.sol
+++ b/contracts/facets/MeTokenRegistryFacet.sol
@@ -58,7 +58,8 @@ contract MeTokenRegistryFacet is Modifiers {
         uint256 _hubId,
         uint256 _assetsDeposited
     ) external {
-        require(!isOwner(msg.sender), "msg.sender already owns a meToken");
+        address sender = LibMeta.msgSender();
+        require(!isOwner(sender), "msg.sender already owns a meToken");
         HubInfo memory hub_ = s.hubs[_hubId];
         require(hub_.active, "Hub inactive");
         require(!hub_.updating, "Hub updating");
@@ -66,7 +67,7 @@ contract MeTokenRegistryFacet is Modifiers {
         if (_assetsDeposited > 0) {
             require(
                 IERC20(hub_.asset).transferFrom(
-                    msg.sender,
+                    sender,
                     hub_.vault,
                     _assetsDeposited
                 ),
@@ -89,21 +90,21 @@ contract MeTokenRegistryFacet is Modifiers {
                 0, // _supply
                 0 // _balancePooled
             );
-            IMeToken(meTokenAddr).mint(msg.sender, _meTokensMinted);
+            IMeToken(meTokenAddr).mint(sender, _meTokensMinted);
         }
 
         // Register the address which created a meToken
-        s.meTokenOwners[msg.sender] = meTokenAddr;
+        s.meTokenOwners[sender] = meTokenAddr;
 
         // Add meToken to registry
-        MeTokenInfo storage meToken_ = s.meTokens[meTokenAddr];
-        meToken_.owner = msg.sender;
-        meToken_.hubId = _hubId;
-        meToken_.balancePooled = _assetsDeposited;
+        // MeTokenInfo storage meToken_ = s.meTokens[meTokenAddr];
+        s.meTokens[meTokenAddr].owner = sender;
+        s.meTokens[meTokenAddr].hubId = _hubId;
+        s.meTokens[meTokenAddr].balancePooled = _assetsDeposited;
 
         emit Subscribe(
             meTokenAddr,
-            msg.sender,
+            sender,
             _meTokensMinted,
             hub_.asset,
             _assetsDeposited,
@@ -122,8 +123,8 @@ contract MeTokenRegistryFacet is Modifiers {
         MeTokenInfo storage meToken_ = s.meTokens[_meToken];
         HubInfo memory hub_ = s.hubs[meToken_.hubId];
         HubInfo memory targetHub_ = s.hubs[_targetHubId];
-
-        require(msg.sender == meToken_.owner, "!owner");
+        address sender = LibMeta.msgSender();
+        require(sender == meToken_.owner, "!owner");
         require(
             block.timestamp >= meToken_.endCooldown,
             "Cooldown not complete"
@@ -180,7 +181,8 @@ contract MeTokenRegistryFacet is Modifiers {
 
     function cancelResubscribe(address _meToken) external {
         MeTokenInfo storage meToken_ = s.meTokens[_meToken];
-        require(msg.sender == meToken_.owner, "!owner");
+        address sender = LibMeta.msgSender();
+        require(sender == meToken_.owner, "!owner");
         require(meToken_.targetHubId != 0, "!resubscribing");
         require(
             block.timestamp < meToken_.startTime,
@@ -197,7 +199,8 @@ contract MeTokenRegistryFacet is Modifiers {
 
     function updateBalances(address _meToken, uint256 _newBalance) external {
         MeTokenInfo storage meToken_ = s.meTokens[_meToken];
-        require(msg.sender == meToken_.migration, "!migration");
+        address sender = LibMeta.msgSender();
+        require(sender == meToken_.migration, "!migration");
         uint256 balancePooled = meToken_.balancePooled;
         uint256 balanceLocked = meToken_.balanceLocked;
         uint256 oldBalance = balancePooled + balanceLocked;
@@ -214,48 +217,48 @@ contract MeTokenRegistryFacet is Modifiers {
     }
 
     function transferMeTokenOwnership(address _newOwner) external {
+        address sender = LibMeta.msgSender();
         require(
-            s.pendingMeTokenOwners[msg.sender] == address(0),
+            s.pendingMeTokenOwners[sender] == address(0),
             "transfer ownership already pending"
         );
         require(!isOwner(_newOwner), "_newOwner already owns a meToken");
         require(_newOwner != address(0), "Cannot transfer to 0 address");
-        address meToken_ = s.meTokenOwners[msg.sender];
+        address meToken_ = s.meTokenOwners[sender];
         require(meToken_ != address(0), "meToken does not exist");
-        s.pendingMeTokenOwners[msg.sender] = _newOwner;
+        s.pendingMeTokenOwners[sender] = _newOwner;
 
-        emit TransferMeTokenOwnership(msg.sender, _newOwner, meToken_);
+        emit TransferMeTokenOwnership(sender, _newOwner, meToken_);
     }
 
     function cancelTransferMeTokenOwnership() external {
-        address _meToken = s.meTokenOwners[msg.sender];
+        address sender = LibMeta.msgSender();
+        address _meToken = s.meTokenOwners[sender];
         require(_meToken != address(0), "meToken does not exist");
 
         require(
-            s.pendingMeTokenOwners[msg.sender] != address(0),
+            s.pendingMeTokenOwners[sender] != address(0),
             "transferMeTokenOwnership() not initiated"
         );
 
-        delete s.pendingMeTokenOwners[msg.sender];
-        emit CancelTransferMeTokenOwnership(msg.sender, _meToken);
+        delete s.pendingMeTokenOwners[sender];
+        emit CancelTransferMeTokenOwnership(sender, _meToken);
     }
 
     function claimMeTokenOwnership(address _oldOwner) external {
-        require(!isOwner(msg.sender), "Already owns a meToken");
-        require(
-            msg.sender == s.pendingMeTokenOwners[_oldOwner],
-            "!_pendingOwner"
-        );
+        address sender = LibMeta.msgSender();
+        require(!isOwner(sender), "Already owns a meToken");
+        require(sender == s.pendingMeTokenOwners[_oldOwner], "!_pendingOwner");
 
         address _meToken = s.meTokenOwners[_oldOwner];
 
-        s.meTokens[_meToken].owner = msg.sender;
-        s.meTokenOwners[msg.sender] = _meToken;
+        s.meTokens[_meToken].owner = sender;
+        s.meTokenOwners[sender] = _meToken;
 
         delete s.meTokenOwners[_oldOwner];
         delete s.pendingMeTokenOwners[_oldOwner];
 
-        emit ClaimMeTokenOwnership(_oldOwner, msg.sender, _meToken);
+        emit ClaimMeTokenOwnership(_oldOwner, sender, _meToken);
     }
 
     function setMeTokenWarmup(uint256 _warmup)


### PR DESCRIPTION
I did not replace msg.sender in details.sol because it feels unnecessary to go through meta transactions for admin functions 