### PR TITLE
feat(migration): migration where only issuer can trigger swap

### DIFF
--- a/contracts/interfaces/IMigration.sol
+++ b/contracts/interfaces/IMigration.sol
@@ -17,10 +17,7 @@ interface IMigration {
     /// @notice Method to send assets from migration vault to the vault of the
     ///         target hub
     /// @param meToken      Address of meToken
-    /// @return amountOut   Amount of token returned
-    function finishMigration(address meToken)
-        external
-        returns (uint256 amountOut);
+    function finishMigration(address meToken) external;
 
     /// @notice Method returns bool if migration started
     /// @param meToken  Address of meToken

--- a/contracts/migrations/SameAssetTransferMigration.sol
+++ b/contracts/migrations/SameAssetTransferMigration.sol
@@ -77,7 +77,6 @@ contract SameAssetTransferMigration is ReentrancyGuard, Vault, IMigration {
         override
         nonReentrant
         onlyDiamond
-        returns (uint256 amountOut)
     {
         MeTokenInfo memory meTokenInfo = IMeTokenRegistryFacet(diamond)
             .getMeTokenInfo(meToken);
@@ -90,7 +89,8 @@ contract SameAssetTransferMigration is ReentrancyGuard, Vault, IMigration {
                 IHubFacet(diamond).getHubInfo(meTokenInfo.hubId).vault
             ).startMigration(meToken);
         }
-        amountOut = meTokenInfo.balancePooled + meTokenInfo.balanceLocked;
+        uint256 amountOut = meTokenInfo.balancePooled +
+            meTokenInfo.balanceLocked;
 
         // Send asset to new vault only if there's a migration vault
         IERC20(targetHubInfo.asset).safeTransfer(

--- a/contracts/migrations/SameAssetTransferMigration.sol
+++ b/contracts/migrations/SameAssetTransferMigration.sol
@@ -29,25 +29,26 @@ contract SameAssetTransferMigration is ReentrancyGuard, Vault, IMigration {
 
     mapping(address => SameAssetMigration) private _sameAssetMigration;
 
+    modifier onlyDiamond() {
+        require(msg.sender == diamond, "!diamond");
+        _;
+    }
+
     constructor(address _dao, address _diamond) Vault(_dao, _diamond) {}
 
     /// @inheritdoc IMigration
     function initMigration(
         address meToken,
         bytes memory /* encodedArgs */
-    ) external override {
-        require(msg.sender == diamond, "!diamond");
-
+    ) external override onlyDiamond {
         MeTokenInfo memory meTokenInfo = IMeTokenRegistryFacet(diamond)
             .getMeTokenInfo(meToken);
-        HubInfo memory hubInfo = IHubFacet(diamond).getHubInfo(
-            meTokenInfo.hubId
-        );
-        HubInfo memory targetHubInfo = IHubFacet(diamond).getHubInfo(
-            meTokenInfo.targetHubId
-        );
 
-        require(hubInfo.asset == targetHubInfo.asset, "asset different");
+        require(
+            IHubFacet(diamond).getHubInfo(meTokenInfo.hubId).asset ==
+                IHubFacet(diamond).getHubInfo(meTokenInfo.targetHubId).asset,
+            "same asset"
+        );
 
         _sameAssetMigration[meToken].isMigrating = true;
     }
@@ -75,24 +76,19 @@ contract SameAssetTransferMigration is ReentrancyGuard, Vault, IMigration {
         external
         override
         nonReentrant
+        onlyDiamond
         returns (uint256 amountOut)
     {
-        require(msg.sender == diamond, "!diamond");
-        SameAssetMigration storage usts = _sameAssetMigration[meToken];
-        require(usts.isMigrating, "!migrating");
-
         MeTokenInfo memory meTokenInfo = IMeTokenRegistryFacet(diamond)
             .getMeTokenInfo(meToken);
-        HubInfo memory hubInfo = IHubFacet(diamond).getHubInfo(
-            meTokenInfo.hubId
-        );
         HubInfo memory targetHubInfo = IHubFacet(diamond).getHubInfo(
             meTokenInfo.targetHubId
         );
 
-        if (!usts.started) {
-            ISingleAssetVault(hubInfo.vault).startMigration(meToken);
-            usts.started = true;
+        if (!_sameAssetMigration[meToken].started) {
+            ISingleAssetVault(
+                IHubFacet(diamond).getHubInfo(meTokenInfo.hubId).vault
+            ).startMigration(meToken);
         }
         amountOut = meTokenInfo.balancePooled + meTokenInfo.balanceLocked;
 
@@ -114,16 +110,14 @@ contract SameAssetTransferMigration is ReentrancyGuard, Vault, IMigration {
         usts = _sameAssetMigration[meToken];
     }
 
-    // Kicks off meToken warmup period
     /// @inheritdoc Vault
     function isValid(
         address meToken,
         bytes memory /* encodedArgs */
     ) external view override returns (bool) {
-        MeTokenInfo memory meTokenInfo = IMeTokenRegistryFacet(diamond)
-            .getMeTokenInfo(meToken);
         // MeToken not subscribed to a hub
-        if (meTokenInfo.hubId == 0) return false;
+        if (IMeTokenRegistryFacet(diamond).getMeTokenInfo(meToken).hubId == 0)
+            return false;
         return true;
     }
 

--- a/contracts/migrations/UniswapSingleTransferMigration.sol
+++ b/contracts/migrations/UniswapSingleTransferMigration.sol
@@ -94,7 +94,6 @@ contract UniswapSingleTransferMigration is ReentrancyGuard, Vault, IMigration {
         override
         nonReentrant
         onlyDiamond
-        returns (uint256 amountOut)
     {
         MeTokenInfo memory meTokenInfo = IMeTokenRegistryFacet(diamond)
             .getMeTokenInfo(meToken);
@@ -102,6 +101,7 @@ contract UniswapSingleTransferMigration is ReentrancyGuard, Vault, IMigration {
             meTokenInfo.targetHubId
         );
 
+        uint256 amountOut;
         if (!_uniswapSingleTransfers[meToken].started) {
             ISingleAssetVault(
                 IHubFacet(diamond).getHubInfo(meTokenInfo.hubId).vault

--- a/contracts/migrations/UniswapSingleTransferMigration2.sol
+++ b/contracts/migrations/UniswapSingleTransferMigration2.sol
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity 0.8.9;
+
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
+import {IHubFacet} from "../interfaces/IHubFacet.sol";
+import {IMeTokenRegistryFacet} from "../interfaces/IMeTokenRegistryFacet.sol";
+import {IMigration} from "../interfaces/IMigration.sol";
+import {ISingleAssetVault} from "../interfaces/ISingleAssetVault.sol";
+import {ISwapRouter} from "@uniswap/v3-periphery/contracts/interfaces/ISwapRouter.sol";
+import {HubInfo} from "../libs/LibHub.sol";
+import {MeTokenInfo} from "../libs/LibMeToken.sol";
+import {Vault} from "../vaults/Vault.sol";
+
+/// @title Vault migrator from erc20 to erc20 (non-lp)
+/// @author Carter Carlson (@cartercarlson), Chris Robison (@cbobrobison), Parv Garg (@parv3213)
+/// @notice create a vault that instantly swaps token A for token B
+///         when recollateralizing to a vault with a different base token
+/// @dev This contract moves the pooled/locked balances from
+///      one erc20 to another
+contract UniswapSingleTransferMigration is ReentrancyGuard, Vault, IMigration {
+    using SafeERC20 for IERC20;
+
+    struct UniswapSingleTransfer {
+        // Fee configured to pay on swap
+        uint24 fee;
+        // if migration is active and startMigration() has not been triggered
+        bool started;
+    }
+
+    mapping(address => UniswapSingleTransfer) private _uniswapSingleTransfers;
+
+    // NOTE: this can be found at
+    // github.com/Uniswap/uniswap-v3-periphery/blob/main/contracts/interfaces/ISwapRouter.sol
+    ISwapRouter private immutable _router =
+        ISwapRouter(0xE592427A0AEce92De3Edee1F18E0157C05861564);
+
+    // args for uniswap router
+    uint24 public constant MINFEE = 500; // 0.05%
+    uint24 public constant MIDFEE = 3000; // 0.3% (Default fee)
+    uint24 public constant MAXFEE = 1e4; // 1%
+
+    modifier onlyDiamond() {
+        require(msg.sender == diamond, "!diamond");
+        _;
+    }
+
+    constructor(address _dao, address _diamond) Vault(_dao, _diamond) {}
+
+    /// @inheritdoc IMigration
+    function initMigration(address meToken, bytes memory encodedArgs)
+        external
+        override
+        onlyDiamond
+    {
+        MeTokenInfo memory meTokenInfo = IMeTokenRegistryFacet(diamond)
+            .getMeTokenInfo(meToken);
+
+        require(
+            IHubFacet(diamond).getHubInfo(meTokenInfo.hubId).asset !=
+                IHubFacet(diamond).getHubInfo(meTokenInfo.targetHubId).asset,
+            "same asset"
+        );
+
+        _uniswapSingleTransfers[meToken].fee = abi.decode(
+            encodedArgs,
+            (uint24)
+        );
+    }
+
+    /// @inheritdoc IMigration
+    function poke(address meToken) external override nonReentrant {
+        UniswapSingleTransfer storage usts = _uniswapSingleTransfers[meToken];
+        MeTokenInfo memory meTokenInfo = IMeTokenRegistryFacet(diamond)
+            .getMeTokenInfo(meToken);
+
+        if (
+            usts.fee != 0 && // make sure meToken is in a state of resubscription
+            block.timestamp > meTokenInfo.startTime && // swap can only happen after resubscribe
+            !usts.started // should skip if already started
+        ) {
+            ISingleAssetVault(
+                IHubFacet(diamond).getHubInfo(meTokenInfo.hubId).vault
+            ).startMigration(meToken);
+            usts.started = true;
+            _swap(meToken);
+        }
+    }
+
+    /// @inheritdoc IMigration
+    function finishMigration(address meToken)
+        external
+        override
+        nonReentrant
+        onlyDiamond
+    {
+        MeTokenInfo memory meTokenInfo = IMeTokenRegistryFacet(diamond)
+            .getMeTokenInfo(meToken);
+        HubInfo memory targetHubInfo = IHubFacet(diamond).getHubInfo(
+            meTokenInfo.targetHubId
+        );
+
+        uint256 amountOut;
+        if (!_uniswapSingleTransfers[meToken].started) {
+            ISingleAssetVault(
+                IHubFacet(diamond).getHubInfo(meTokenInfo.hubId).vault
+            ).startMigration(meToken);
+            amountOut = _swap(meToken);
+        } else {
+            // No swap, amountOut = amountIn
+            amountOut = meTokenInfo.balancePooled + meTokenInfo.balanceLocked;
+        }
+
+        // Send asset to new vault only if there's a migration vault
+        IERC20(targetHubInfo.asset).safeTransfer(
+            targetHubInfo.vault,
+            amountOut
+        );
+
+        // reset mappings
+        delete _uniswapSingleTransfers[meToken];
+    }
+
+    function getDetails(address meToken)
+        external
+        view
+        returns (UniswapSingleTransfer memory usts)
+    {
+        usts = _uniswapSingleTransfers[meToken];
+    }
+
+    /// @inheritdoc Vault
+    function isValid(address meToken, bytes memory encodedArgs)
+        external
+        view
+        override
+        returns (bool)
+    {
+        // encodedArgs empty
+        if (encodedArgs.length == 0) return false;
+
+        MeTokenInfo memory meTokenInfo = IMeTokenRegistryFacet(diamond)
+            .getMeTokenInfo(meToken);
+        uint24 fee = abi.decode(encodedArgs, (uint24));
+
+        // MeToken not subscribed to a hub
+        if (meTokenInfo.hubId == 0) return false;
+        // Invalid fee
+        if (fee == MINFEE || fee == MIDFEE || fee == MAXFEE) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /// @inheritdoc IMigration
+    function migrationStarted(address meToken)
+        external
+        view
+        override
+        returns (bool started)
+    {
+        return _uniswapSingleTransfers[meToken].started;
+    }
+
+    /// @dev parent call must have reentrancy check
+    function _swap(address meToken) private returns (uint256 amountOut) {
+        UniswapSingleTransfer storage usts = _uniswapSingleTransfers[meToken];
+        MeTokenInfo memory meTokenInfo = IMeTokenRegistryFacet(diamond)
+            .getMeTokenInfo(meToken);
+        HubInfo memory hubInfo = IHubFacet(diamond).getHubInfo(
+            meTokenInfo.hubId
+        );
+        HubInfo memory targetHubInfo = IHubFacet(diamond).getHubInfo(
+            meTokenInfo.targetHubId
+        );
+        uint256 amountIn = meTokenInfo.balancePooled +
+            meTokenInfo.balanceLocked;
+
+        // Only swap if
+        // - There are tokens to swap
+        // - The resubscription has started
+        // - The asset hasn't been swapped
+        // - Current time is past the startTime it can swap, and time to swap has been set
+        if (amountIn == 0) {
+            return 0;
+        }
+
+        // Approve router to spend
+        IERC20(hubInfo.asset).safeApprove(address(_router), amountIn);
+
+        // https://docs.uniswap.org/protocol/guides/swaps/single-swaps
+        ISwapRouter.ExactInputSingleParams memory params = ISwapRouter
+            .ExactInputSingleParams({
+                tokenIn: hubInfo.asset,
+                tokenOut: targetHubInfo.asset,
+                fee: usts.fee,
+                recipient: address(this),
+                deadline: block.timestamp,
+                amountIn: amountIn,
+                amountOutMinimum: 0,
+                sqrtPriceLimitX96: 0
+            });
+
+        // The call to `exactInputSingle` executes the swap
+        amountOut = _router.exactInputSingle(params);
+
+        // Based on amountIn and amountOut, update balancePooled and balanceLocked
+        IMeTokenRegistryFacet(diamond).updateBalances(meToken, amountOut);
+    }
+}

--- a/test/contracts/migrations/UniswapSingleTransfer.ts
+++ b/test/contracts/migrations/UniswapSingleTransfer.ts
@@ -64,10 +64,9 @@ const setup = async () => {
     let encodedVaultDAIArgs: string;
     let encodedVaultWETHArgs: string;
     let block;
-    let migrationDetails: [number, boolean, boolean] & {
+    let migrationDetails: [number, boolean] & {
       fee: number;
       started: boolean;
-      swapped: boolean;
     };
 
     before(async () => {
@@ -337,7 +336,6 @@ const setup = async () => {
           .to.emit(meTokenRegistry, "UpdateBalances");
         migrationDetails = await migration.getDetails(meToken.address);
         expect(migrationDetails.started).to.be.equal(true);
-        expect(migrationDetails.swapped).to.be.equal(true);
       });
       it("should be able to call when migration already started, but wont run startMigration()", async () => {
         const tx = await migration.poke(meToken.address);
@@ -380,7 +378,6 @@ const setup = async () => {
         migrationDetails = await migration.getDetails(meToken.address);
         expect(migrationDetails.fee).to.equal(0);
         expect(migrationDetails.started).to.equal(false);
-        expect(migrationDetails.swapped).to.equal(false);
       });
       it("should revert before endTime", async () => {
         let meTokenRegistryDetails = await meTokenRegistry.getMeTokenInfo(
@@ -455,7 +452,6 @@ const setup = async () => {
         migrationDetails = await migration.getDetails(meToken.address);
         expect(migrationDetails.fee).to.equal(0);
         expect(migrationDetails.started).to.equal(false);
-        expect(migrationDetails.swapped).to.equal(false);
       });
 
       describe("During resubscribe", () => {


### PR DESCRIPTION
- `_swap` can only be called when `msg.sender=meTokenIssuer`.
- This allows the issuer to examine the conditions and swap at a favourable time.
- With this migration contract, `mint` and `burn` would revert after `warmup` until the migration is finished.
- Only once the `_swap` is complete, `started=true`, the migration would finish.

Please review the concept, @cartercarlson @zgorizzo69.